### PR TITLE
 Allow deserializing cfg/timers/en from int|bool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/paulwrath1223/wled-json-api-library"
 [dependencies]
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"
+serde-aux-ext = "0.2.0"
 reqwest = { version = "0.11.22", features = ["gzip", "blocking"] }
 serde_repr = "0.1.17"
 thiserror = "1.0.50"

--- a/src/structures/cfg/cfg_timers.rs
+++ b/src/structures/cfg/cfg_timers.rs
@@ -1,6 +1,7 @@
 use serde;
 use serde::{Serialize, Deserialize};
 use crate::structures::none_function;
+use serde_aux_ext::field_attributes::deserialize_option_bool_from_anything;
 
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -56,6 +57,7 @@ pub struct Goal {
 #[serde(rename_all = "camelCase")]
 pub struct Ins {
     /// enabled?
+    #[serde(deserialize_with = "deserialize_option_bool_from_anything")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default = "none_function")]
     pub en: Option<bool>,


### PR DESCRIPTION
 - 0.14.x seem to encode the timers enable flag as an int, despite it being a boolean value.
 - Use serde extras to deserialized EITHER an int or bool to a bool
 - Works on my machine ;) against 0.14.1 and 0.14.2b1

Sorry about the dependency add, but I didn't want to add a custom deserializer for the structs either, so this was a pragmatic (read as quick) solution.